### PR TITLE
Add badge evaluation service and API endpoints

### DIFF
--- a/admin/badges.py
+++ b/admin/badges.py
@@ -1,0 +1,421 @@
+"""Badge evaluation logic for Nutrios admin."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Dict, Iterable, List, Optional
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from .analysis import df_meals, summary_extras, summary_macros
+from .models import ClientTargets
+
+
+DEFAULT_TARGETS = {
+    "kcal_target": 2000,
+    "protein_target_g": 100,
+    "fat_target_g": 70,
+    "carbs_target_g": 250,
+    "tolerances": {
+        "kcal_pct": 0.10,
+        "protein_pct": 0.20,
+        "fat_pct": 0.20,
+        "carbs_pct": 0.20,
+        "min_g": {"p": 10, "f": 10, "c": 15},
+    },
+}
+
+
+@dataclass
+class BadgeEvaluation:
+    earned: bool
+    progress: float
+    meta: Optional[Dict[str, float]] = None
+
+
+@dataclass
+class BadgeContext:
+    session: Session
+    client_id: int
+    meals: pd.DataFrame
+    daily_macros: pd.DataFrame
+    daily_extras: pd.DataFrame
+    targets: Dict[str, object]
+    compliance_bools: List[bool]
+    compliance_segments: List[tuple[bool, int]]
+    current_streak: int
+    best_streak: int
+
+
+@dataclass
+class Badge:
+    code: str
+    title: str
+    description: str
+    evaluator: Callable[[BadgeContext], BadgeEvaluation]
+
+
+def _ensure_dataframe(obj: object) -> pd.DataFrame:
+    if isinstance(obj, pd.DataFrame):
+        return obj.copy()
+    return pd.DataFrame()
+
+
+def _load_targets(session: Session, client_id: int) -> Dict[str, object]:
+    row = session.query(ClientTargets).filter_by(client_id=client_id).first()
+    if not row:
+        return DEFAULT_TARGETS.copy()
+    tolerances = row.tolerances or DEFAULT_TARGETS["tolerances"]
+    return {
+        "kcal_target": row.kcal_target,
+        "protein_target_g": row.protein_target_g,
+        "fat_target_g": row.fat_target_g,
+        "carbs_target_g": row.carbs_target_g,
+        "tolerances": tolerances,
+    }
+
+
+def _safe_float(value: object) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _default_tolerances(targets: Dict[str, object]) -> Dict[str, object]:
+    tol = targets.get("tolerances") if targets else None
+    if not tol:
+        tol = DEFAULT_TARGETS["tolerances"]
+    tol.setdefault("min_g", DEFAULT_TARGETS["tolerances"]["min_g"])
+    return tol
+
+
+def _is_day_compliant(row: pd.Series, targets: Dict[str, object]) -> bool:
+    if not isinstance(row, pd.Series) or not targets:
+        return False
+    tol = _default_tolerances(targets)
+    try:
+        kcal_target = float(targets.get("kcal_target") or 0)
+        protein_target = float(targets.get("protein_target_g") or 0)
+        fat_target = float(targets.get("fat_target_g") or 0)
+        carbs_target = float(targets.get("carbs_target_g") or 0)
+    except Exception:
+        return False
+
+    kcal = _safe_float(row.get("kcal"))
+    protein = _safe_float(row.get("protein_g"))
+    fat = _safe_float(row.get("fat_g"))
+    carbs = _safe_float(row.get("carbs_g"))
+
+    if None in (kcal, protein, fat, carbs):
+        return False
+
+    def within(actual: float, target: float, pct: float, min_g: float = 0.0) -> bool:
+        if target <= 0:
+            return False
+        allowed = max(min_g, target * pct)
+        return abs(actual - target) <= allowed
+
+    try:
+        kcal_ok = within(kcal, kcal_target, tol.get("kcal_pct", 0.1))
+        protein_ok = within(protein, protein_target, tol.get("protein_pct", 0.2), tol.get("min_g", {}).get("p", 10))
+        fat_ok = within(fat, fat_target, tol.get("fat_pct", 0.2), tol.get("min_g", {}).get("f", 10))
+        carbs_ok = within(carbs, carbs_target, tol.get("carbs_pct", 0.2), tol.get("min_g", {}).get("c", 15))
+    except Exception:
+        return False
+    return kcal_ok and protein_ok and fat_ok and carbs_ok
+
+
+def _fill_compliance_gaps(sorted_rows: List[tuple[datetime, bool]]) -> List[bool]:
+    if not sorted_rows:
+        return []
+    result: List[bool] = []
+    previous_date: Optional[datetime] = None
+    for date, compliant in sorted_rows:
+        if previous_date is not None:
+            delta = (date.date() - previous_date.date()).days
+            for _ in range(1, max(delta, 0)):
+                result.append(False)
+        result.append(bool(compliant))
+        previous_date = date
+    return result
+
+
+def _segments_from_bools(bools: Iterable[bool]) -> List[tuple[bool, int]]:
+    segments: List[tuple[bool, int]] = []
+    current_val: Optional[bool] = None
+    current_len = 0
+    for value in bools:
+        if current_val is None:
+            current_val = value
+            current_len = 1
+            continue
+        if value == current_val:
+            current_len += 1
+        else:
+            segments.append((current_val, current_len))
+            current_val = value
+            current_len = 1
+    if current_val is not None:
+        segments.append((current_val, current_len))
+    return segments
+
+
+def _build_context(session: Session, client_id: int) -> BadgeContext:
+    meals = df_meals(session, client_id)
+    daily_macros = _ensure_dataframe(summary_macros(meals, freq="D"))
+    daily_extras = _ensure_dataframe(summary_extras(meals, freq="D"))
+    if not daily_macros.empty and "captured_at" in daily_macros.columns:
+        daily_macros = daily_macros.sort_values("captured_at")
+    if not daily_extras.empty and "captured_at" in daily_extras.columns:
+        daily_extras = daily_extras.sort_values("captured_at")
+
+    targets = _load_targets(session, client_id)
+    compliance_source: List[tuple[datetime, bool]] = []
+    if not daily_macros.empty:
+        for _, row in daily_macros.iterrows():
+            captured = row.get("captured_at")
+            if isinstance(captured, pd.Timestamp):
+                captured_dt = captured.to_pydatetime()
+            else:
+                captured_dt = captured if isinstance(captured, datetime) else None
+            if not captured_dt:
+                continue
+            compliant = _is_day_compliant(row, targets)
+            compliance_source.append((captured_dt, compliant))
+
+    compliance_bools = _fill_compliance_gaps(compliance_source)
+    segments = _segments_from_bools(compliance_bools)
+    current_streak = 0
+    for compliant in reversed(compliance_bools):
+        if compliant:
+            current_streak += 1
+        else:
+            break
+    best_streak = 0
+    for compliant, length in segments:
+        if compliant:
+            best_streak = max(best_streak, length)
+
+    return BadgeContext(
+        session=session,
+        client_id=client_id,
+        meals=meals,
+        daily_macros=daily_macros,
+        daily_extras=daily_extras,
+        targets=targets,
+        compliance_bools=compliance_bools,
+        compliance_segments=segments,
+        current_streak=current_streak,
+        best_streak=best_streak,
+    )
+
+
+def _eval_first_meal(ctx: BadgeContext) -> BadgeEvaluation:
+    total_meals = 0 if ctx.meals is None else len(ctx.meals.index) if isinstance(ctx.meals, pd.DataFrame) else len(ctx.meals)
+    earned = total_meals > 0
+    progress = 1.0 if earned else 0.0
+    return BadgeEvaluation(earned=earned, progress=progress, meta={"total_meals": float(total_meals)})
+
+
+def _eval_steady_week(ctx: BadgeContext) -> BadgeEvaluation:
+    required = 7
+    progress = min(1.0, ctx.current_streak / required) if required else 0.0
+    earned = ctx.current_streak >= required
+    return BadgeEvaluation(
+        earned=earned,
+        progress=progress,
+        meta={
+            "current_streak": float(ctx.current_streak),
+            "best_streak": float(ctx.best_streak),
+        },
+    )
+
+
+def _eval_fiber_fan(ctx: BadgeContext) -> BadgeEvaluation:
+    if ctx.daily_extras.empty or "fiber_total" not in ctx.daily_extras.columns:
+        return BadgeEvaluation(earned=False, progress=0.0, meta={"days": 0.0, "avg_fiber": 0.0})
+    rows = []
+    for _, row in ctx.daily_extras.iterrows():
+        captured = row.get("captured_at")
+        if isinstance(captured, pd.Timestamp):
+            captured_dt = captured.to_pydatetime()
+        elif isinstance(captured, datetime):
+            captured_dt = captured
+        else:
+            continue
+        fiber = _safe_float(row.get("fiber_total")) or 0.0
+        rows.append((captured_dt, fiber))
+    if not rows:
+        return BadgeEvaluation(earned=False, progress=0.0, meta={"days": 0.0, "avg_fiber": 0.0})
+    rows.sort(key=lambda x: x[0])
+    unique_by_day: Dict[datetime, float] = {}
+    for captured_dt, fiber in rows:
+        unique_by_day[captured_dt.date()] = fiber
+    last_days = list(sorted(unique_by_day.keys()))[-7:]
+    values = [unique_by_day[d] for d in last_days]
+    days_count = len(values)
+    avg_fiber = sum(values) / days_count if days_count else 0.0
+    target_avg = 25.0
+    earned = days_count >= 3 and avg_fiber >= target_avg
+    coverage_progress = min(1.0, days_count / 3.0) if days_count else 0.0
+    avg_progress = min(1.0, avg_fiber / target_avg) if target_avg else 0.0
+    progress = min(1.0, (coverage_progress + avg_progress) / 2) if days_count else 0.0
+    return BadgeEvaluation(
+        earned=earned,
+        progress=progress,
+        meta={"days": float(days_count), "avg_fiber": float(round(avg_fiber, 2))},
+    )
+
+
+def _eval_omega_balance(ctx: BadgeContext) -> BadgeEvaluation:
+    if ctx.daily_extras.empty:
+        return BadgeEvaluation(earned=False, progress=0.0, meta={"days": 0.0, "in_range": 0.0})
+    rows = []
+    for _, row in ctx.daily_extras.iterrows():
+        captured = row.get("captured_at")
+        if isinstance(captured, pd.Timestamp):
+            captured_dt = captured.to_pydatetime()
+        elif isinstance(captured, datetime):
+            captured_dt = captured
+        else:
+            continue
+        ratio = row.get("omega_ratio_num")
+        if ratio is None and {"omega6", "omega3"}.issubset(row.index):
+            ratio = _compute_ratio(row.get("omega6"), row.get("omega3"))
+        ratio_f = _safe_float(ratio)
+        rows.append((captured_dt, ratio_f))
+    if not rows:
+        return BadgeEvaluation(earned=False, progress=0.0, meta={"days": 0.0, "in_range": 0.0})
+    rows.sort(key=lambda x: x[0])
+    unique_by_day: Dict[datetime, Optional[float]] = {}
+    for captured_dt, ratio in rows:
+        unique_by_day[captured_dt.date()] = ratio
+    last_days = list(sorted(unique_by_day.keys()))[-7:]
+    ratios = [unique_by_day[d] for d in last_days if unique_by_day[d] is not None]
+    days_with_ratio = len(ratios)
+    in_range = len([r for r in ratios if 2.0 <= r <= 5.0])
+    required_days = 3
+    earned = in_range >= required_days
+    progress = 0.0
+    if required_days:
+        progress = min(1.0, in_range / required_days)
+    return BadgeEvaluation(
+        earned=earned,
+        progress=progress,
+        meta={"days": float(days_with_ratio), "in_range": float(in_range)},
+    )
+
+
+def _compute_ratio(omega6: object, omega3: object) -> Optional[float]:
+    six = _safe_float(omega6)
+    three = _safe_float(omega3)
+    if six is None or three in (None, 0):
+        return None
+    try:
+        return round(six / three, 2)
+    except Exception:
+        return None
+
+
+def _eval_hero_return(ctx: BadgeContext) -> BadgeEvaluation:
+    segments = ctx.compliance_segments
+    if not segments or not segments[-1][0]:
+        return BadgeEvaluation(
+            earned=False,
+            progress=0.0,
+            meta={
+                "current_streak": float(ctx.current_streak),
+                "previous_best": float(ctx.best_streak),
+                "break_length": 0.0,
+            },
+        )
+    current_len = segments[-1][1]
+    break_len = segments[-2][1] if len(segments) >= 2 and not segments[-2][0] else 0
+    previous_best = 0
+    if len(segments) >= 3:
+        for compliant, length in reversed(segments[:-2]):
+            if compliant:
+                previous_best = max(previous_best, length)
+                if previous_best >= 5:
+                    break
+    progress_parts: List[float] = []
+    progress_parts.append(min(1.0, current_len / 3.0))
+    if previous_best:
+        progress_parts.append(min(1.0, previous_best / 5.0))
+    else:
+        progress_parts.append(0.0)
+    if break_len:
+        progress_parts.append(min(1.0, break_len / 3.0))
+    else:
+        progress_parts.append(0.0)
+    progress = sum(progress_parts) / len(progress_parts) if progress_parts else 0.0
+    earned = current_len >= 3 and break_len >= 3 and previous_best >= 5
+    return BadgeEvaluation(
+        earned=earned,
+        progress=min(1.0, progress),
+        meta={
+            "current_streak": float(ctx.current_streak),
+            "previous_best": float(previous_best),
+            "break_length": float(break_len),
+        },
+    )
+
+
+BADGES: List[Badge] = [
+    Badge(
+        code="first_meal",
+        title="Первый шаг",
+        description="Клиент зафиксировал первую запись о приёме пищи.",
+        evaluator=_eval_first_meal,
+    ),
+    Badge(
+        code="steady_week",
+        title="В ритме недели",
+        description="7 дней подряд придерживается целевых макросов.",
+        evaluator=_eval_steady_week,
+    ),
+    Badge(
+        code="fiber_fan",
+        title="Фанат клетчатки",
+        description="Среднее потребление клетчатки ≥ 25 г минимум три дня за последнюю неделю.",
+        evaluator=_eval_fiber_fan,
+    ),
+    Badge(
+        code="omega_balance",
+        title="Баланс омега",
+        description="Баланс омега-6/омега-3 в диапазоне 2–5 не менее трёх дней за неделю.",
+        evaluator=_eval_omega_balance,
+    ),
+    Badge(
+        code="hero_return",
+        title="Возвращение героя",
+        description="После перерыва вернулся к плану и держит новую серию не менее трёх дней.",
+        evaluator=_eval_hero_return,
+    ),
+]
+
+
+def evaluate_badges(session: Session, client_id: int) -> List[Dict[str, object]]:
+    """Evaluate all badges for the client and return structured progress."""
+
+    ctx = _build_context(session, client_id)
+    results: List[Dict[str, object]] = []
+    for badge in BADGES:
+        evaluation = badge.evaluator(ctx)
+        results.append(
+            {
+                "code": badge.code,
+                "title": badge.title,
+                "description": badge.description,
+                "earned": bool(evaluation.earned),
+                "progress": float(max(0.0, min(1.0, evaluation.progress or 0.0))),
+                "meta": evaluation.meta or {},
+            }
+        )
+    return results
+

--- a/admin/models.py
+++ b/admin/models.py
@@ -2,7 +2,6 @@ from sqlalchemy import Column, Integer, Float, String, Boolean, ForeignKey, Date
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 from .db import Base
-from sqlalchemy import UniqueConstraint
 
 class Client(Base):
     __tablename__ = "clients"
@@ -11,6 +10,7 @@ class Client(Base):
     telegram_username = Column(String, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     meals = relationship("Meal", back_populates="client")
+    badge_awards = relationship("ClientBadgeAward", back_populates="client", cascade="all, delete-orphan")
 
 class Meal(Base):
     __tablename__ = "meals"
@@ -52,3 +52,16 @@ class ClientTargets(Base):
     notifications = Column(JSON, nullable=True) # preferences: {reminders:true, time:"08:00", tips:true}
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
+class ClientBadgeAward(Base):
+    __tablename__ = "client_badge_awards"
+
+    id = Column(Integer, primary_key=True)
+    client_id = Column(Integer, ForeignKey("clients.id"), index=True, nullable=False)
+    badge_code = Column(String, nullable=False)
+    awarded_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+
+    client = relationship("Client", back_populates="badge_awards")
+
+    __table_args__ = (UniqueConstraint("client_id", "badge_code", name="uq_client_badge"),)

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from admin.api import refresh_client_badges
+from admin.badges import evaluate_badges
+from admin.db import Base
+from admin.models import Client, Meal, ClientBadgeAward
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSession = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db_session = TestingSession()
+    try:
+        yield db_session
+    finally:
+        db_session.close()
+
+
+def _create_client(session, telegram_user_id: int = 100) -> Client:
+    client = Client(telegram_user_id=telegram_user_id)
+    session.add(client)
+    session.commit()
+    session.refresh(client)
+    return client
+
+
+def _add_meal(
+    session,
+    client_id: int,
+    captured_at: datetime,
+    kcal: int = 2000,
+    protein: int = 100,
+    fat: int = 70,
+    carbs: int = 250,
+    fiber: float = 30.0,
+    omega6: float = 6.0,
+    omega3: float = 3.0,
+):
+    extras = {
+        "fiber": {"total": fiber},
+        "fats": {"omega6": omega6, "omega3": omega3},
+    }
+    meal = Meal(
+        client_id=client_id,
+        message_id=int(captured_at.timestamp()),
+        title="Test",
+        portion_g=300,
+        confidence=100,
+        kcal=kcal,
+        protein_g=protein,
+        fat_g=fat,
+        carbs_g=carbs,
+        flags={},
+        micronutrients=[],
+        assumptions=[],
+        extras=extras,
+        source_type="test",
+        captured_at=captured_at,
+        created_at=captured_at,
+        updated_at=captured_at,
+    )
+    session.add(meal)
+
+
+def test_badge_conditions_met_and_awarded(session):
+    client = _create_client(session, telegram_user_id=200)
+    base = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+
+    # Initial compliant streak (5 days)
+    for day in range(5):
+        _add_meal(session, client.id, base + timedelta(days=day))
+
+    # New compliant streak after three skipped days (7 days)
+    for day in range(8, 15):
+        _add_meal(session, client.id, base + timedelta(days=day))
+
+    session.commit()
+
+    statuses = evaluate_badges(session, client.id)
+    by_code = {row["code"]: row for row in statuses}
+
+    assert by_code["first_meal"]["earned"] is True
+    assert by_code["steady_week"]["earned"] is True
+    assert by_code["fiber_fan"]["earned"] is True
+    assert by_code["omega_balance"]["earned"] is True
+    assert by_code["hero_return"]["earned"] is True
+
+    refreshed = refresh_client_badges(session, client.id)
+    assert all(row["earned"] for row in refreshed)
+    award_codes = {award.badge_code for award in session.query(ClientBadgeAward).all()}
+    assert award_codes == set(by_code.keys())
+
+    # Second refresh should not create duplicates
+    second = refresh_client_badges(session, client.id)
+    assert len(session.query(ClientBadgeAward).all()) == len(by_code)
+    refreshed_map = {row["code"]: row for row in refreshed}
+    second_map = {row["code"]: row for row in second}
+    assert refreshed_map.keys() == second_map.keys()
+    for code in refreshed_map:
+        assert refreshed_map[code]["earned"] == second_map[code]["earned"]
+        assert refreshed_map[code]["progress"] == second_map[code]["progress"]
+        assert refreshed_map[code]["latest_award_at"] == second_map[code]["latest_award_at"]
+
+
+def test_badge_conditions_not_met(session):
+    client = _create_client(session, telegram_user_id=300)
+
+    statuses = evaluate_badges(session, client.id)
+    by_code = {row["code"]: row for row in statuses}
+
+    assert by_code["first_meal"]["earned"] is False
+    assert by_code["steady_week"]["earned"] is False
+    assert by_code["fiber_fan"]["earned"] is False
+    assert by_code["omega_balance"]["earned"] is False
+    assert by_code["hero_return"]["earned"] is False
+
+    refreshed = refresh_client_badges(session, client.id)
+    assert all(row["earned"] is False for row in refreshed)
+    assert session.query(ClientBadgeAward).count() == 0


### PR DESCRIPTION
## Summary
- implement badge evaluation logic describing badge catalogue and progress tracking
- store earned badge timestamps via a new ClientBadgeAward model and expose admin API endpoints for refresh/get
- cover badge logic and award deduplication with pytest-based unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce74f9e554832c8ca51f335d6414d7