### PR TITLE
Add experiment management APIs with RBAC and AB service integration

### DIFF
--- a/admin/ab_service.py
+++ b/admin/ab_service.py
@@ -1,0 +1,83 @@
+import logging
+import os
+from typing import Mapping, Optional
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+
+class ABFlagServiceError(RuntimeError):
+    """Raised when the AB flag service fails to apply a configuration."""
+
+
+class ABFlagService:
+    """Simple client for pushing experiment configurations to the AB flag service."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self.base_url = base_url or os.getenv("ABFLAG_BASE_URL")
+        self.api_key = api_key or os.getenv("ABFLAG_API_KEY")
+        self.timeout = timeout
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _post(self, path: str, payload: dict) -> None:
+        if not self.base_url:
+            logger.debug("ABFlagService base URL not configured; skipping request to %s", path)
+            return
+        url = f"{self.base_url.rstrip('/')}{path}"
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.post(url, json=payload, headers=self._build_headers())
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.error("ABFlagService request to %s failed: %s", url, exc)
+            raise ABFlagServiceError(str(exc)) from exc
+
+    def publish_experiment(
+        self,
+        experiment_key: str,
+        rollout_percentage: float,
+        variant_weights: Mapping[str, float],
+        preserve_sticky_assignments: bool = True,
+    ) -> None:
+        payload = {
+            "rollout_percentage": rollout_percentage,
+            "variant_weights": dict(variant_weights),
+            "preserve_sticky_assignments": preserve_sticky_assignments,
+        }
+        self._post(f"/experiments/{experiment_key}/publish", payload)
+
+    def pause_experiment(self, experiment_key: str) -> None:
+        self._post(f"/experiments/{experiment_key}/pause", {"preserve_sticky_assignments": True})
+
+    def resume_experiment(
+        self,
+        experiment_key: str,
+        rollout_percentage: float,
+        variant_weights: Mapping[str, float],
+    ) -> None:
+        # Resuming is equivalent to publishing the latest configuration.
+        self.publish_experiment(
+            experiment_key,
+            rollout_percentage,
+            variant_weights,
+            preserve_sticky_assignments=True,
+        )
+
+
+def get_ab_service() -> ABFlagService:
+    """Factory used by FastAPI dependency injection."""
+
+    return ABFlagService()
+

--- a/admin/auth.py
+++ b/admin/auth.py
@@ -1,5 +1,68 @@
-from fastapi import Header, HTTPException
+import json
+from dataclasses import dataclass
+from typing import Set
+
+from fastapi import Depends, Header, HTTPException
+
 from config import ADMIN_API_KEY
-async def require_api_key(x_api_key: str = Header(None)):
+
+
+@dataclass
+class AdminIdentity:
+    """Represents the authenticated admin making the request."""
+
+    api_key: str
+    roles: Set[str]
+    subject: str | None = None
+
+
+def _parse_roles(raw: str | None) -> Set[str]:
+    roles: Set[str] = set()
+    if not raw:
+        return roles
+    raw = raw.strip()
+    if not raw:
+        return roles
+    # Accept JSON encoded lists as well as comma separated values.
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, (list, tuple)):
+                for value in parsed:
+                    if isinstance(value, str) and value.strip():
+                        roles.add(value.strip().lower())
+        except json.JSONDecodeError:
+            # Fall back to comma-separated parsing below.
+            pass
+    if not roles:
+        for part in raw.split(","):
+            part = part.strip()
+            if part:
+                roles.add(part.lower())
+    return roles
+
+
+async def require_api_key(
+    x_api_key: str = Header(None),
+    x_admin_roles: str = Header(default=""),
+    x_admin_user: str | None = Header(default=None),
+) -> AdminIdentity:
     if x_api_key != ADMIN_API_KEY:
         raise HTTPException(status_code=401, detail="Invalid API key")
+    return AdminIdentity(api_key=x_api_key, roles=_parse_roles(x_admin_roles), subject=x_admin_user)
+
+
+def require_roles(*required_roles: str):
+    required = {r.lower() for r in required_roles if r}
+
+    async def _checker(identity: AdminIdentity = Depends(require_api_key)) -> AdminIdentity:
+        if not required:
+            return identity
+        if "admin" in identity.roles:
+            return identity
+        missing = [r for r in required if r not in identity.roles]
+        if missing:
+            raise HTTPException(status_code=403, detail="Missing required roles: " + ", ".join(sorted(required)))
+        return identity
+
+    return _checker

--- a/test_experiments_api.py
+++ b/test_experiments_api.py
@@ -1,0 +1,161 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from admin.api import app, get_db
+from admin.ab_service import get_ab_service
+from admin.models import Base, Experiment, ExperimentRevision, ExperimentVariant
+
+
+class DummyABService:
+    def __init__(self) -> None:
+        self.published: list[dict] = []
+        self.paused: list[str] = []
+        self.resumed: list[dict] = []
+
+    def publish_experiment(self, experiment_key: str, rollout_percentage: float, variant_weights, preserve_sticky_assignments: bool = True):
+        self.published.append(
+            {
+                "experiment_key": experiment_key,
+                "rollout_percentage": rollout_percentage,
+                "variant_weights": dict(variant_weights),
+                "preserve_sticky_assignments": preserve_sticky_assignments,
+            }
+        )
+
+    def pause_experiment(self, experiment_key: str):
+        self.paused.append(experiment_key)
+
+    def resume_experiment(self, experiment_key: str, rollout_percentage: float, variant_weights):
+        self.resumed.append(
+            {
+                "experiment_key": experiment_key,
+                "rollout_percentage": rollout_percentage,
+                "variant_weights": dict(variant_weights),
+            }
+        )
+
+
+@pytest.fixture()
+def experiment_client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    service = DummyABService()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_ab_service] = lambda: service
+
+    with TestingSessionLocal() as session:
+        session.add(Experiment(key="exp_signup", rollout_percentage=10.0))
+        session.commit()
+
+    with TestClient(app) as client:
+        yield client, service, TestingSessionLocal
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_ab_service, None)
+
+
+def _auth_headers(*roles: str) -> dict[str, str]:
+    role_value = ",".join(roles)
+    return {"x-api-key": "supersecret", "x-admin-roles": role_value}
+
+
+def test_experiment_workflow_publish_pause_resume(experiment_client):
+    client, service, SessionLocal = experiment_client
+
+    headers = _auth_headers("experiments:write", "experiments:publish")
+
+    # Invalid weights should be rejected.
+    invalid_resp = client.put(
+        "/experiments/exp_signup/config",
+        json={
+            "rollout_percentage": 20,
+            "variants": [
+                {"name": "control", "weight": 60},
+                {"name": "test", "weight": 10},
+            ],
+        },
+        headers=headers,
+    )
+    assert invalid_resp.status_code == 422
+
+    # Update with valid weights (percentages that normalise to 1.0)
+    update_resp = client.put(
+        "/experiments/exp_signup/config",
+        json={
+            "rollout_percentage": 25,
+            "variants": [
+                {"name": "control", "weight": 60},
+                {"name": "test", "weight": 40},
+            ],
+        },
+        headers=headers,
+    )
+    assert update_resp.status_code == 200
+    payload = update_resp.json()
+    assert payload["experiment"]["rollout_percentage"] == 25.0
+    weights = {v["name"]: v["weight"] for v in payload["experiment"]["variants"]}
+    assert pytest.approx(sum(weights.values()), rel=1e-6) == 1.0
+    assert pytest.approx(weights["control"], rel=1e-6) == 0.6
+    assert pytest.approx(weights["test"], rel=1e-6) == 0.4
+
+    with SessionLocal() as session:
+        experiment = session.query(Experiment).filter_by(key="exp_signup").first()
+        assert experiment.rollout_percentage == 25.0
+        stored_weights = {v.name: v.weight for v in session.query(ExperimentVariant).filter_by(experiment_id=experiment.id)}
+        assert pytest.approx(stored_weights["control"], rel=1e-6) == 0.6
+        assert pytest.approx(stored_weights["test"], rel=1e-6) == 0.4
+
+    publish_resp = client.post("/experiments/exp_signup/publish", headers=headers)
+    assert publish_resp.status_code == 200
+    publish_body = publish_resp.json()
+    assert publish_body["experiment"]["status"] == "running"
+    assert publish_body["revision"]["revision"] == 1
+    assert service.published[-1]["experiment_key"] == "exp_signup"
+    assert service.published[-1]["preserve_sticky_assignments"] is True
+
+    with SessionLocal() as session:
+        revision = session.query(ExperimentRevision).filter_by(experiment_id=experiment.id).first()
+        assert revision is not None
+        assert revision.status == "running"
+
+    pause_resp = client.post("/experiments/exp_signup/pause", headers=headers)
+    assert pause_resp.status_code == 200
+    assert pause_resp.json()["experiment"]["status"] == "paused"
+    assert service.paused[-1] == "exp_signup"
+
+    resume_resp = client.post("/experiments/exp_signup/resume", headers=headers)
+    assert resume_resp.status_code == 200
+    assert resume_resp.json()["experiment"]["status"] == "running"
+    assert service.resumed[-1]["experiment_key"] == "exp_signup"
+    assert pytest.approx(service.resumed[-1]["variant_weights"]["control"], rel=1e-6) == 0.6
+
+
+def test_experiment_requires_roles(experiment_client):
+    client, _, _ = experiment_client
+
+    resp = client.put(
+        "/experiments/exp_signup/config",
+        json={
+            "rollout_percentage": 10,
+            "variants": [{"name": "control", "weight": 1}],
+        },
+        headers={"x-api-key": "supersecret"},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add Experiment, ExperimentVariant, and ExperimentRevision models to store rollout and history
- implement RBAC-aware endpoints for updating configs, publishing revisions, and pausing/resuming experiments while wiring the AB flag service client
- introduce unit tests that exercise the workflow with a stub AB flag service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce704b5154832c819e5b00a3071e1b