### PR TITLE
Add client metrics/events tracking and surface updates to bot and miniapp

### DIFF
--- a/bot/ingest_client.py
+++ b/bot/ingest_client.py
@@ -1,9 +1,19 @@
 import logging
+from datetime import datetime, timezone, date
+from typing import Dict, Any, Optional
+
 import httpx
-from typing import Dict, Any
+
 from config import ADMIN_API_BASE, ADMIN_API_KEY
 
-def ingest_meal(payload: Dict[str, Any]) -> None:
+_CLIENT_ID_CACHE: Dict[int, int] = {}
+
+
+def _auth_headers() -> Dict[str, str]:
+    return {"x-api-key": ADMIN_API_KEY} if ADMIN_API_KEY else {}
+
+
+def ingest_meal(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
     payload включает:
       telegram_user_id, telegram_username, captured_at_iso,
@@ -15,12 +25,123 @@ def ingest_meal(payload: Dict[str, Any]) -> None:
         try:
             r = client.post(
                 f"{ADMIN_API_BASE}/ingest/meal",
-                headers={"x-api-key": ADMIN_API_KEY},
+                headers=_auth_headers(),
                 json=payload,
             )
             if r.status_code >= 400:
                 logging.getLogger(__name__).warning(
                     "Admin ingest failed: %s %s", r.status_code, r.text[:200]
                 )
+                return None
+            data = r.json() if r.content else None
+            if isinstance(data, dict):
+                cid = data.get("client_id")
+                uid = payload.get("telegram_user_id")
+                if cid and uid:
+                    _CLIENT_ID_CACHE[int(uid)] = int(cid)
+            return data
         except Exception as e:
             logging.getLogger(__name__).warning("Admin ingest error: %s", e)
+            return None
+
+
+def _get_client_id(telegram_user_id: int) -> Optional[int]:
+    if telegram_user_id in _CLIENT_ID_CACHE:
+        return _CLIENT_ID_CACHE[telegram_user_id]
+    with httpx.Client(timeout=10.0) as client:
+        try:
+            r = client.get(
+                f"{ADMIN_API_BASE}/clients",
+                headers=_auth_headers(),
+            )
+            if r.status_code >= 400:
+                logging.getLogger(__name__).warning(
+                    "Admin client lookup failed: %s %s", r.status_code, r.text[:200]
+                )
+                return None
+            for row in r.json() or []:
+                if row.get("telegram_user_id") == telegram_user_id:
+                    cid = row.get("id")
+                    if cid:
+                        _CLIENT_ID_CACHE[telegram_user_id] = int(cid)
+                        return int(cid)
+        except Exception as e:
+            logging.getLogger(__name__).warning("Admin client lookup error: %s", e)
+    return None
+
+
+def _ensure_iso_date(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str):
+        return value
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _ensure_iso_datetime(value: Any) -> str:
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    if isinstance(value, str):
+        return value
+    return datetime.now(timezone.utc).isoformat()
+
+
+def upsert_daily_metrics_for_user(telegram_user_id: int, metrics: Dict[str, Any]) -> bool:
+    client_id = _get_client_id(telegram_user_id)
+    if not client_id:
+        logging.getLogger(__name__).warning("No client id for telegram_user_id=%s", telegram_user_id)
+        return False
+    payload = dict(metrics)
+    payload["date"] = _ensure_iso_date(payload.get("date"))
+    with httpx.Client(timeout=10.0) as client:
+        try:
+            r = client.put(
+                f"{ADMIN_API_BASE}/clients/{client_id}/metrics/daily",
+                headers=_auth_headers(),
+                json=payload,
+            )
+            if r.status_code >= 400:
+                logging.getLogger(__name__).warning(
+                    "Admin metrics upsert failed: %s %s", r.status_code, r.text[:200]
+                )
+                return False
+            return True
+        except Exception as e:
+            logging.getLogger(__name__).warning("Admin metrics upsert error: %s", e)
+            return False
+
+
+def post_event_for_user(telegram_user_id: int, event: Dict[str, Any]) -> bool:
+    client_id = _get_client_id(telegram_user_id)
+    if not client_id:
+        logging.getLogger(__name__).warning("No client id for event telegram_user_id=%s", telegram_user_id)
+        return False
+    payload = dict(event)
+    if "type" not in payload:
+        logging.getLogger(__name__).warning("Event payload missing type: %s", payload)
+        return False
+    if "date" in payload:
+        payload["date"] = _ensure_iso_date(payload.get("date"))
+    else:
+        payload["date"] = datetime.now(timezone.utc).date().isoformat()
+    if "occurred_at" in payload:
+        payload["occurred_at"] = _ensure_iso_datetime(payload.get("occurred_at"))
+    with httpx.Client(timeout=10.0) as client:
+        try:
+            r = client.post(
+                f"{ADMIN_API_BASE}/clients/{client_id}/events",
+                headers=_auth_headers(),
+                json=payload,
+            )
+            if r.status_code >= 400:
+                logging.getLogger(__name__).warning(
+                    "Admin event post failed: %s %s", r.status_code, r.text[:200]
+                )
+                return False
+            return True
+        except Exception as e:
+            logging.getLogger(__name__).warning("Admin event post error: %s", e)
+            return False

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -34,6 +34,30 @@
       </section>
 
       <section class="card">
+        <div class="section-title">Ежедневные отметки</div>
+        <div id="dailyMetricsStatus" class="metrics-status muted">Нет данных за сегодня</div>
+        <div class="actions-grid">
+          <button id="markWater" class="btn btn-secondary">💧 Вода выполнена</button>
+          <form id="stepsForm" class="inline-form">
+            <input type="number" id="stepsInput" min="0" placeholder="Шаги" />
+            <button type="submit" class="btn">Сохранить шаги</button>
+          </form>
+          <button id="markDinner" class="btn btn-secondary">🍽️ Ужин отмечен</button>
+          <button id="markNewRecipe" class="btn btn-secondary">🆕 Новый рецепт</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="section-title">Челленджи и события</div>
+        <div class="actions-vertical">
+          <button id="btnChallenge" class="btn btn-secondary">🏁 Челлендж выполнен</button>
+          <button id="btnShareProgress" class="btn btn-secondary">📣 Поделиться прогрессом</button>
+          <button id="btnStreakResumed" class="btn btn-secondary">🔥 Серия возобновлена</button>
+        </div>
+        <div id="eventsList" class="events-list muted"></div>
+      </section>
+
+      <section class="card">
         <div class="section-title">Опросник (цели и состояние)</div>
         <form id="quiz" class="form-grid">
           <label>Возраст<input type="number" name="age" min="10" max="100" /></label>

--- a/miniapp/styles.css
+++ b/miniapp/styles.css
@@ -22,9 +22,20 @@ main { padding: 16px; display: grid; gap: 12px; }
 .kpi .meta { font-size: 12px; color: var(--muted); }
 .btn { background: var(--accent); color: white; border: none; border-radius: 10px; padding: 10px 14px; font-weight: 600; }
 .btn:active { transform: translateY(1px); }
+.btn-secondary { background: #1f2230; color: var(--text); border: 1px solid #2c364d; }
+.btn-secondary:active { transform: translateY(1px); }
 .form-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0,1fr)); }
 label { display: grid; font-size: 12px; gap: 4px; }
 input, select { background: #0f141f; color: var(--text); border: 1px solid #243048; border-radius: 10px; padding: 10px; }
+.inline-form { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.inline-form input { flex: 1; min-width: 120px; }
+.actions-grid { display: grid; gap: 8px; margin-top: 12px; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.actions-vertical { display: grid; gap: 8px; margin-top: 12px; }
+.metrics-status { margin-bottom: 8px; font-size: 14px; }
+.events-list { margin-top: 12px; display: grid; gap: 6px; font-size: 12px; line-height: 1.4; }
+.event-item { background: #0e1320; border: 1px solid #1f2638; border-radius: 10px; padding: 8px 10px; }
+.event-item .muted { margin-top: 4px; }
+.muted { color: var(--muted); }
 .streak { font-size: 18px; }
 .ok { color: var(--ok); }
 .warn { color: var(--warn); }


### PR DESCRIPTION
## Summary
- add ClientDailyMetrics and ClientEvents tables with DB bootstrap helpers
- expose REST endpoints for daily metrics and client events with validation and idempotent upserts
- extend bot ingestion helpers, add commands for water/steps/dinner/new recipe logging, and record portion adjustment events
- enhance the miniapp to capture daily marks and events and document manual workflows for nutritionists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce74f84f20832ca8eb20f414d307d0